### PR TITLE
Additional NULL check in find_

### DIFF
--- a/src/quadtree.c
+++ b/src/quadtree.c
@@ -82,6 +82,9 @@ split_node_(quadtree_t *tree, quadtree_node_t *node){
 
 static quadtree_point_t*
 find_(quadtree_node_t* node, double x, double y) {
+  if(!node){
+    retrun NULL;
+  }
   if(quadtree_node_isleaf(node)){
     if(node->point->x == x && node->point->y == y)
       return node->point;

--- a/src/quadtree.c
+++ b/src/quadtree.c
@@ -83,7 +83,7 @@ split_node_(quadtree_t *tree, quadtree_node_t *node){
 static quadtree_point_t*
 find_(quadtree_node_t* node, double x, double y) {
   if(!node){
-    retrun NULL;
+    return NULL;
   }
   if(quadtree_node_isleaf(node)){
     if(node->point->x == x && node->point->y == y)


### PR DESCRIPTION
If I'm searching a point that is not contained by the tree, I'll get a segfault, because of quadtree.c line 92.
If get_quadrant_ returns NULL, then in the next find_ -> quadtree_node_isleaf call, will crash.
